### PR TITLE
[chore] GPT 리뷰어 등록 및 cicd 코드 변경

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
         run: npm run build
         working-directory: ./fe
 
-      - name: 테스트 실행 중..
-        run: npm run test
-        working-directory: ./fe
+      # - name: 테스트 실행 중..
+      #   run: npm run test
+      #   working-directory: ./fe
 
-      - name: 코드 린트 체크 중..
-        run: npm run lint
-        working-directory: ./fe
+      # - name: 코드 린트 체크 중..
+      #   run: npm run lint
+      #   working-directory: ./fe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:
@@ -17,13 +17,18 @@ jobs:
         with:
           node-version: '18.18.2'
 
-      - name: pnpm 설치중..
-        run: npm install -g pnpm
-
       - name: 종속성 설치중...
-        run: pnpm install
+        run: npm install
         working-directory: ./fe
 
       - name: 빌드 중..
-        run: pnpm build
+        run: npm run build
+        working-directory: ./fe
+
+      - name: 테스트 실행 중..
+        run: npm run test
+        working-directory: ./fe
+
+      - name: 코드 린트 체크 중..
+        run: npm run lint
         working-directory: ./fe

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
+        working-directory: ./fe
+        
       - name: Run GPT-based Code Review
         uses: anc95/ChatGPT-CodeReview@main
         with:

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,0 +1,32 @@
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        # actions/checkout의 최신 버전 사용
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18' # Node.js의 최신 LTS 버전으로 업데이트
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run GPT-based Code Review
+        uses: anc95/ChatGPT-CodeReview@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LANGUAGE: 'TypeScript' # 프로젝트의 언어를 TypeScript로 설정
+          MAX_COMMENTS: 5 # 리뷰어가 생성할 최대 코멘트 수


### PR DESCRIPTION
## #️⃣연관 이슈

> #109 

## 📝작업 내용

- GitHub Actions 설정에서 pnpm 대신 npm 사용으로 변경.
- 리뷰어 자동화 도구로 ChatGPT를 통합.
- CI/CD 트리거에 `develop` 브랜치를 추가하여 `main` 브랜치와 함께 동작하도록 설정.

## 추가 사항

- 설정 변경 후, `develop` 및 `main` 브랜치에 대해 CI/CD가 올바르게 트리거되는지 확인 필요.
- 변경된 CI/CD 프로세스의 테스트 케이스 실행 및 빌드 성능 모니터링.

## 💬리뷰 요구사항(선택)

- 설정 파일의 변경 사항에 대한 상세한 리뷰를 요청합니다.
- 특히, npm의 설정과 ChatGPT 리뷰어 통합 부분에 주목해 주시기 바랍니다.
